### PR TITLE
fix: wait for all drawings to be ready before creating the masks

### DIFF
--- a/src/particle-effects/drawings-mask.js
+++ b/src/particle-effects/drawings-mask.js
@@ -2,7 +2,13 @@ import { packageId } from "../constants.js";
 
 export function registeDrawingsMaskFunctionality() {
   Hooks.on("canvasReady", () => {
-    requestAnimationFrame(drawDrawingsMask);
+    Hooks.once(`${packageId}.drawingsReady`, drawDrawingsMask);
+  });
+
+  Hooks.on("refreshDrawing", (drawing) => {
+    if (canvas.drawings.placeables.every(drawing => drawing.shape.geometry.graphicsData.length > 0)) {
+      Hooks.call(`${packageId}.drawingsReady`);
+    }
   });
 
   for (const hook of ["updateDrawing", "createDrawing", "deleteDrawing"]) {

--- a/src/particle-effects/drawings-mask.js
+++ b/src/particle-effects/drawings-mask.js
@@ -5,8 +5,8 @@ export function registeDrawingsMaskFunctionality() {
     Hooks.once(`${packageId}.drawingsReady`, drawDrawingsMask);
   });
 
-  Hooks.on("refreshDrawing", (drawing) => {
-    if (canvas.drawings.placeables.every(drawing => drawing.shape.geometry.graphicsData.length > 0)) {
+  Hooks.on("refreshDrawing", () => {
+    if (canvas.drawings.placeables.every((drawing) => drawing.shape.geometry.graphicsData.length > 0)) {
       Hooks.call(`${packageId}.drawingsReady`);
     }
   });


### PR DESCRIPTION
Cleaner approach to issue #718: check that all the drawings have their geometry/graphics data ready before creating the masks.