### PR TITLE
Added caching to mod settings checks for improved processing times

### DIFF
--- a/src/settings-access.js
+++ b/src/settings-access.js
@@ -1,14 +1,57 @@
 import { packageId } from "./constants.js";
 
 /**
+ * Cached setting values, keyed by setting name.
+ * 
+ * Avoids WorldSettings#getSetting - linear scan of all settings documents,
+ * which adds latency that can add up with enough call frequency.
+ *
+ * @type {Map<string, boolean>}
+ */
+const settingCache = new Map();
+let cacheHooksRegistered = false;
+
+/**
+ * Read a cached boolean module setting.
+ * 
+ * Invalidates on any possible action that can result in a setting change.
+ * Failed reads are not cached and hooks register on first use
+ * 
+ * @param {string} key
+ * @returns {boolean}
+ */
+function cachedFlag(key) {
+  const hit = settingCache.get(key);
+  if (hit !== undefined) return hit;
+
+  const settings = globalThis.game?.settings;
+  if (!settings) return false;
+
+  if (!cacheHooksRegistered) {
+    cacheHooksRegistered = true;
+    const invalidate = () => settingCache.clear();
+    Hooks.on("updateSetting", invalidate);
+    Hooks.on("createSetting", invalidate);
+    Hooks.on("clientSettingChanged", invalidate);
+  }
+
+  let value;
+  try {
+    value = settings.get(packageId, key) === true;
+  } catch (_err) {
+    return false;
+  }
+  settingCache.set(key, value);
+  return value;
+}
+
+/**
  * Determine whether FXMaster effects are globally enabled.
  *
  * @returns {boolean} Whether the module is enabled for the current world and client.
  */
 export function isEnabled() {
-  return (
-    globalThis.game?.settings?.get(packageId, "enable") && !globalThis.game?.settings?.get(packageId, "disableAll")
-  );
+  return cachedFlag("enable") && !cachedFlag("disableAll");
 }
 
 /**
@@ -17,11 +60,7 @@ export function isEnabled() {
  * @returns {boolean}
  */
 export function applyRegionBehaviorsToOverheadLevels() {
-  try {
-    return globalThis.game?.settings?.get(packageId, "applyRegionBehaviorsToOverheadLevels") === true;
-  } catch (_err) {
-    return false;
-  }
+  return cachedFlag("applyRegionBehaviorsToOverheadLevels");
 }
 
 /**
@@ -30,11 +69,7 @@ export function applyRegionBehaviorsToOverheadLevels() {
  * @returns {boolean}
  */
 export function compositeGridInFxStack() {
-  try {
-    return globalThis.game?.settings?.get(packageId, "compositeGridInFxStack") === true;
-  } catch (_err) {
-    return false;
-  }
+  return cachedFlag("compositeGridInFxStack");
 }
 
 /**
@@ -43,11 +78,7 @@ export function compositeGridInFxStack() {
  * @returns {boolean}
  */
 export function displayEffectsOverVision() {
-  try {
-    return globalThis.game?.settings?.get(packageId, "displayEffectsOverVision") === true;
-  } catch (_err) {
-    return false;
-  }
+  return cachedFlag("displayEffectsOverVision");
 }
 
 /**
@@ -56,9 +87,5 @@ export function displayEffectsOverVision() {
  * @returns {boolean}
  */
 export function disableGridMovementHighlighting() {
-  try {
-    return globalThis.game?.settings?.get(packageId, "disableGridMovementHighlighting") === true;
-  } catch (_err) {
-    return false;
-  }
+  return cachedFlag("disableGridMovementHighlighting");
 }


### PR DESCRIPTION
Module setting checks now read from a small cache instead of calling game.settings.get directly.

ClientSettings#get resolves a world-scoped setting through WorldSettings#getSetting, which is this.find(s => (s.key === key) && (s.user === user)) — a linear scan over every Setting document in the world, not just this module's, allocating a string and a closure per call. Measured at ~14.7 µs per call on my world.

Since isEnabled() gates the refreshToken listener in hooks/token-hooks.js, which fires once per token per frame, testing with a six-token drag resulted in 1,618 calls per second, two settings reads each, about 45ms per second to answer two booleans. With caching, the same calls cost 1.7ms per second. Not a world changing performance boost, but significant if you're already struggling to maintain good FPS.

All five accessors in settings-access.js go through one cachedFlag(key) helper, invalidated on updateSetting / createSetting / clientSettingChanged. World-scope writes go through Setting#update/Setting.create so the document hooks fire cross-client (GM toggles reach player clients); client-scope writes fire clientSettingChanged (client-settings.mjs:321) - the hooks capture all routes that can modify a setting.

One behavior change: isEnabled() had no try/catch and would throw if settings weren't registered; it now returns false and doesn't cache the failure, since reads happen before registration during init.